### PR TITLE
Some improvements for the blood castle event

### DIFF
--- a/docs/Packets/C1-9B-BloodCastleState_by-server.md
+++ b/docs/Packets/C1-9B-BloodCastleState_by-server.md
@@ -15,9 +15,20 @@ The client side shows a message about the changing state.
 | 0 | 1 |   Byte   | 0xC1  | [Packet type](PacketTypes.md) |
 | 1 | 1 |    Byte   |   13   | Packet header - length of the packet |
 | 2 | 1 |    Byte   | 0x9B  | Packet header - packet type identifier |
-| 3 | 1 | Byte |  | State |
+| 3 | 1 | Status |  | State |
 | 4 | 2 | ShortLittleEndian |  | RemainSecond |
 | 6 | 2 | ShortLittleEndian |  | MaxMonster |
 | 8 | 2 | ShortLittleEndian |  | CurMonster |
 | 10 | 2 | ShortLittleEndian |  | ItemOwner |
 | 12 | 1 | Byte |  | ItemLevel |
+
+### Status Enum
+
+Defines the status of the event.
+
+| Value | Name | Description |
+|-------|------|-------------|
+| 0 | Started | The event has just started and is running. |
+| 1 | GateNotDestroyed | The event is running, but the gate is not destroyed. |
+| 2 | Ended | The event has ended. |
+| 4 | GateDestroyed | The event is running and the gate is destroyed. |

--- a/src/GameLogic/MiniGames/BloodCastleContext.cs
+++ b/src/GameLogic/MiniGames/BloodCastleContext.cs
@@ -68,6 +68,8 @@ public sealed class BloodCastleContext : MiniGameContext
 
     private int PlayerCount => this._gameStates.Count;
 
+    private bool EndedSuccessfully => this.State == MiniGameState.Ended && this._winner is not null;
+
     /// <summary>
     /// Player interact with Archangel.
     /// </summary>
@@ -244,7 +246,12 @@ public sealed class BloodCastleContext : MiniGameContext
         {
             rank++;
             state.Rank = rank;
-            this.GiveRewards(state.Player, rank);
+
+            if (this.EndedSuccessfully)
+            {
+                this.GiveRewards(state.Player, rank);
+            }
+
             scoreList.Add((
                 state.Player.Name,
                 state.Score,
@@ -265,8 +272,9 @@ public sealed class BloodCastleContext : MiniGameContext
     {
         if (this._highScoreTable is { } table)
         {
+            var isSuccessful = this._winner is not null;
             var (name, score, bonusMoney, bonusExp) = table.First(t => t.Name == player.Name);
-            player.ViewPlugIns.GetPlugIn<IBloodCastleScoreTableViewPlugin>()?.ShowScoreTable(true, name, score, bonusExp, bonusMoney);
+            player.ViewPlugIns.GetPlugIn<IBloodCastleScoreTableViewPlugin>()?.ShowScoreTable(isSuccessful, name, score, bonusExp, bonusMoney);
         }
     }
 

--- a/src/GameLogic/MiniGames/BloodCastleItemExtensions.cs
+++ b/src/GameLogic/MiniGames/BloodCastleItemExtensions.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="BloodCastleItemExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.MiniGames;
+
+using System.Diagnostics.CodeAnalysis;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+
+/// <summary>
+/// Item-related extension methods for the blood castle event.
+/// </summary>
+public static class BloodCastleItemExtensions
+{
+    private static readonly (short Group, short Number) ArchangelQuestItemId = (13, 19);
+
+    /// <summary>
+    /// Determines whether an item definition is that of the archangel quest item.
+    /// </summary>
+    /// <param name="itemDefinition">The item definition.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified item definition is the archangel quest item; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsArchangelQuestItem(this ItemDefinition itemDefinition)
+    {
+        return itemDefinition?.Group == ArchangelQuestItemId.Group && itemDefinition.Number == ArchangelQuestItemId.Number;
+    }
+
+    /// <summary>
+    /// Determines whether the item is the archangel quest item.
+    /// </summary>
+    /// <param name="item">The item.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified item is the archangel quest item; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsArchangelQuestItem(this Item item)
+    {
+        return item.Definition?.IsArchangelQuestItem() ?? false;
+    }
+
+    /// <summary>
+    /// Tries to get the quest item from the players inventory.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="item">The quest item.</param>
+    /// <returns>The success.</returns>
+    public static bool TryGetQuestItem(this Player player, [MaybeNullWhen(false)] out Item item)
+    {
+        item = player.Inventory!.Items.FirstOrDefault(i => i.IsArchangelQuestItem());
+        return item is not null;
+    }
+}

--- a/src/GameLogic/MiniGames/IBloodCastleStateViewPlugin.cs
+++ b/src/GameLogic/MiniGames/IBloodCastleStateViewPlugin.cs
@@ -7,18 +7,44 @@ namespace MUnique.OpenMU.GameLogic.MiniGames;
 using MUnique.OpenMU.GameLogic.Views;
 
 /// <summary>
-/// Interface of a view whose implementation informs about the state of a blood castle event.
+/// Interface of a view whose implementation informs about the status of a blood castle event.
 /// </summary>
 public interface IBloodCastleStateViewPlugin : IViewPlugIn
 {
     /// <summary>
     /// Update the state of the blood castle event.
     /// </summary>
-    /// <param name="state">The state of the blood castle event.</param>
-    /// <param name="remainSecond">The remaining time of the blood castle event.</param>
+    /// <param name="status">The status of the blood castle event.</param>
+    /// <param name="remainingTime">The remaining time of the blood castle event.</param>
     /// <param name="maxMonster">Maximum number of monsters to kill.</param>
     /// <param name="curMonster">Current number of monsters killed.</param>
-    /// <param name="itemOwner">The item ownwe.</param>
-    /// <param name="itemLevel">The item level.</param>
-    void UpdateState(byte state, int remainSecond, int maxMonster, int curMonster, int itemOwner, byte itemLevel);
+    /// <param name="questItemOwner">The player which picked up the quest item.</param>
+    /// <param name="questItem">The quest item which was dropped by the statue.</param>
+    void UpdateState(BloodCastleStatus status, TimeSpan remainingTime, int maxMonster, int curMonster, IIdentifiable? questItemOwner, Item? questItem);
+}
+
+/// <summary>
+/// The status of a blood castle event.
+/// </summary>
+public enum BloodCastleStatus
+{
+    /// <summary>
+    /// The event has just started and is running.
+    /// </summary>
+    Started,
+
+    /// <summary>
+    /// The event is running, but the gate is not destroyed.
+    /// </summary>
+    GateNotDestroyed,
+
+    /// <summary>
+    /// The event is running and the gate is destroyed.
+    /// </summary>
+    GateDestroyed,
+
+    /// <summary>
+    /// The event has ended.
+    /// </summary>
+    Ended,
 }

--- a/src/GameLogic/MiniGames/MiniGameContext.cs
+++ b/src/GameLogic/MiniGames/MiniGameContext.cs
@@ -81,6 +81,11 @@ public class MiniGameContext : Disposable, IEventStateProvider
     protected ILogger Logger { get; }
 
     /// <summary>
+    /// Gets the <see cref="CancellationToken"/> which is cancelled when the game ends.
+    /// </summary>
+    protected CancellationToken GameEndedToken => this._gameEndedCts.Token;
+
+    /// <summary>
     /// Tries to enter the mini game. It will fail, if it's full, of if it's not in an open state.
     /// </summary>
     /// <param name="player">The player which tries to enter.</param>
@@ -536,6 +541,7 @@ public class MiniGameContext : Disposable, IEventStateProvider
         try
         {
             this.State = MiniGameState.Ended;
+            this._gameEndedCts.Cancel();
         }
         finally
         {

--- a/src/GameLogic/MiniGames/MiniGameContext.cs
+++ b/src/GameLogic/MiniGames/MiniGameContext.cs
@@ -460,20 +460,13 @@ public class MiniGameContext : Disposable, IEventStateProvider
 
             await this.StartAsync().ConfigureAwait(false);
 
-            bool timeout = true;
             try
             {
                 await Task.Delay(gameDuration, this._gameEndedCts.Token).ConfigureAwait(false);
             }
             catch (TaskCanceledException)
             {
-                this.Logger.LogInformation("Finishing event earlier");
-                timeout = false;
-            }
-
-            if (timeout)
-            {
-                throw new Exception("MiniGameTimeout");
+                this.Logger.LogInformation("Finished event earlier");
             }
 
             await this.StopAsync().ConfigureAwait(false);

--- a/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
+++ b/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
@@ -4734,13 +4734,13 @@ public static class ConnectionExtensions
     /// <param name="remainSecond">The remain second.</param>
     /// <param name="maxMonster">The max monster.</param>
     /// <param name="curMonster">The cur monster.</param>
-    /// <param name="itemOwner">The item owner.</param>
+    /// <param name="itemOwnerId">The item owner id.</param>
     /// <param name="itemLevel">The item level.</param>
     /// <remarks>
     /// Is sent by the server when: The state of a blood castle event is about to change.
     /// Causes reaction on client side: The client side shows a message about the changing state.
     /// </remarks>
-    public static void SendBloodCastleState(this IConnection connection, BloodCastleState.Status @state, ushort @remainSecond, ushort @maxMonster, ushort @curMonster, ushort @itemOwner, byte @itemLevel)
+    public static void SendBloodCastleState(this IConnection connection, BloodCastleState.Status @state, ushort @remainSecond, ushort @maxMonster, ushort @curMonster, ushort @itemOwnerId, byte @itemLevel)
     {
         using var writer = connection.StartWriteBloodCastleState();
         var packet = writer.Packet;
@@ -4748,7 +4748,7 @@ public static class ConnectionExtensions
         packet.RemainSecond = @remainSecond;
         packet.MaxMonster = @maxMonster;
         packet.CurMonster = @curMonster;
-        packet.ItemOwner = @itemOwner;
+        packet.ItemOwnerId = @itemOwnerId;
         packet.ItemLevel = @itemLevel;
         writer.Commit();
     }}

--- a/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
+++ b/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
@@ -4740,7 +4740,7 @@ public static class ConnectionExtensions
     /// Is sent by the server when: The state of a blood castle event is about to change.
     /// Causes reaction on client side: The client side shows a message about the changing state.
     /// </remarks>
-    public static void SendBloodCastleState(this IConnection connection, byte @state, ushort @remainSecond, ushort @maxMonster, ushort @curMonster, ushort @itemOwner, byte @itemLevel)
+    public static void SendBloodCastleState(this IConnection connection, BloodCastleState.Status @state, ushort @remainSecond, ushort @maxMonster, ushort @curMonster, ushort @itemOwner, byte @itemLevel)
     {
         using var writer = connection.StartWriteBloodCastleState();
         var packet = writer.Packet;

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
@@ -22703,9 +22703,9 @@ public readonly ref struct BloodCastleState
     }
 
     /// <summary>
-    /// Gets or sets the item owner.
+    /// Gets or sets the item owner id.
     /// </summary>
-    public ushort ItemOwner
+    public ushort ItemOwnerId
     {
         get => ReadUInt16LittleEndian(this._data[10..]);
         set => WriteUInt16LittleEndian(this._data[10..], value);

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
@@ -22592,6 +22592,32 @@ public readonly ref struct BloodCastleEnterResult
 /// </summary>
 public readonly ref struct BloodCastleState
 {
+    /// <summary>
+    /// Defines the status of the event.
+    /// </summary>
+    public enum Status
+    {
+        /// <summary>
+        /// The event has just started and is running.
+        /// </summary>
+            Started = 0,
+
+        /// <summary>
+        /// The event is running, but the gate is not destroyed.
+        /// </summary>
+            GateNotDestroyed = 1,
+
+        /// <summary>
+        /// The event has ended.
+        /// </summary>
+            Ended = 2,
+
+        /// <summary>
+        /// The event is running and the gate is destroyed.
+        /// </summary>
+            GateDestroyed = 4,
+    }
+
     private readonly Span<byte> _data;
 
     /// <summary>
@@ -22643,10 +22669,10 @@ public readonly ref struct BloodCastleState
     /// <summary>
     /// Gets or sets the state.
     /// </summary>
-    public byte State
+    public BloodCastleState.Status State
     {
-        get => this._data[3];
-        set => this._data[3] = value;
+        get => (Status)this._data[3];
+        set => this._data[3] = (byte)value;
     }
 
     /// <summary>

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
@@ -8134,7 +8134,8 @@
       <Fields>
         <Field>
           <Index>3</Index>
-          <Type>Byte</Type>
+          <Type>Enum</Type>
+          <TypeName>Status</TypeName>
           <Name>State</Name>
         </Field>
         <Field>
@@ -8155,7 +8156,7 @@
         <Field>
           <Index>10</Index>
           <Type>ShortLittleEndian</Type>
-          <Name>ItemOwner</Name>
+          <Name>ItemOwnerId</Name>
         </Field>
         <Field>
           <Index>12</Index>
@@ -8163,6 +8164,34 @@
           <Name>ItemLevel</Name>
         </Field>
       </Fields>
+      <Enums>
+        <Enum>
+          <Name>Status</Name>
+          <Description>Defines the status of the event.</Description>
+          <Values>
+            <EnumValue>
+              <Name>Started</Name>
+              <Description>The event has just started and is running.</Description>
+              <Value>0</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>GateNotDestroyed</Name>
+              <Description>The event is running, but the gate is not destroyed.</Description>
+              <Value>1</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Ended</Name>
+              <Description>The event has ended.</Description>
+              <Value>2</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>GateDestroyed</Name>
+              <Description>The event is running and the gate is destroyed.</Description>
+              <Value>4</Value>
+            </EnumValue>
+          </Values>
+        </Enum>
+      </Enums>
     </Packet>
   </Packets>
   <Enums>


### PR DESCRIPTION
* Reduced the number of magic values by introducing enums and constants
* Handling of missing values for the quest item and quest item owner should be done in the implementation of the view plugin. Also the id of the owner needs to be substituted with GetId(this._player).
* some fixes for async code
* getting the required definitions for the quest item and statue during initialization, so that when that fails the event wont even start and waste more time
* instead of creating the persistent Item, create a temporary item. It will automatically get persistent when it gets picked up, though.
* more comments and improved naming